### PR TITLE
pip syntax corrected (typo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Note: This repository contains codes for windows platform only, if you want to u
 
 ### Required Modules
 ```
->> pip install opencv-contrib-python
->> pip install numpy
->> pip install pyautogui
->> pip install imutils
->> pip install pillow
->> pip install psutils
->> pip install zipfile
+pip install opencv-contrib-python
+pip install numpy
+pip install pyautogui
+pip install imutils
+pip install pillow
+pip install psutils
+pip install zipfile
 ```
 
 ### Problem


### PR DESCRIPTION
Required Modules/Dependencies syntax corrected, for ease of copy/pasting or bulk execution.</br>

**If I directly copy the commands from `README.md` and past them on terminal**</br>

![image](https://user-images.githubusercontent.com/80936610/170886420-87949c38-259d-4e1d-8dd1-480f7e6f3ae5.png)

## Before : 
![image](https://user-images.githubusercontent.com/80936610/170886333-b8d94f3a-0165-4b42-8d9e-7c94d9c43dbc.png)
## After :
![image](https://user-images.githubusercontent.com/80936610/170886344-02878087-aae7-48a6-99c9-445517889ed7.png)
